### PR TITLE
bounty: Add CW721 support to Keplr

### DIFF
--- a/BOUNTIES.md
+++ b/BOUNTIES.md
@@ -45,4 +45,5 @@ These bounties relate to adding better CosmWasm support as well as code examples
 
 | Task                                              | Description                                                                                                                                                                                 | Reward   | PR  | Claimed by |
 | :------------------------------------------------ | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | :------- | --- | :--------- |
-| Add CW721 support to Keplr | This may need discussion with the Keplr team - implement support for CW721 NFTs within Keplr wallet. Please include a link to the PR on Keplr. | 500 JUNO |     |            |
+| Add CW721 support to Keplr | This may need discussion with the Keplr team - implement support for CW721 NFTs within Keplr wallet. Please include a link to the PR on Keplr. | 500 JUNO |   WIP  |  Genuine-Hedgehog
+          |


### PR DESCRIPTION
Work in progress.
We (@blucbo and @dmytrobaida) are going to add support of CW721 contract to Keplr wallet
Here you can find draft design of feature we are going to implement

![telegram-cloud-document-2-5217722443812049649](https://user-images.githubusercontent.com/15806101/154272894-d325db4b-786a-4012-858c-352fc1f1eb78.jpg)